### PR TITLE
WP_PREFIX in docker-compose was causing migration issues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,6 @@ services:
       DB_USER: wordpress
       DB_PASSWORD: wordpress
       DB_HOST: mysql
-      DB_PREFIX: moj_
     depends_on:
       - mysql
       - mailcatcher


### PR DESCRIPTION
Removed the WP_PREFIX env var from docker-compose.yml to fix local migration operations.