### PR TITLE
Remove Nightingale WP theme

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,6 @@
     "relevanssi/relevanssi-premium": "*",
     "ministryofjustice/wp-moj-components": "*",
     "ministryofjustice/wp-user-roles": "*",
-    "ministryofjustice/nightingale":"dev-master",
     "ministryofjustice/wp-hale":"dev-main",
     "ministryofjustice/cookie-compliance-for-wordpress": "dev-master",
     "ministryofjustice/wp-moj-blocks": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8712f1b947274cdf822796f5c32cd932",
+    "content-hash": "d7997a7a2fa71014b37ebee59bb49fab",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -637,27 +637,6 @@
                 "issues": "https://github.com/ministryofjustice/cookie-compliance-for-wordpress/issues"
             },
             "time": "2020-10-28T18:19:59+00:00"
-        },
-        {
-            "name": "ministryofjustice/nightingale",
-            "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ministryofjustice/nightingale.git",
-                "reference": "c4340bc106be8cbdbe8fb1c386a3ec45a720a0bb"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ministryofjustice/nightingale/zipball/c4340bc106be8cbdbe8fb1c386a3ec45a720a0bb",
-                "reference": "c4340bc106be8cbdbe8fb1c386a3ec45a720a0bb",
-                "shasum": ""
-            },
-            "type": "wordpress-theme",
-            "description": "Nightingale generic theme",
-            "support": {
-                "source": "https://github.com/ministryofjustice/nightingale/tree/master"
-            },
-            "time": "2020-10-15T13:50:10+00:00"
         },
         {
             "name": "ministryofjustice/wp-hale",
@@ -1514,7 +1493,6 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "ministryofjustice/nightingale": 20,
         "ministryofjustice/wp-hale": 20,
         "ministryofjustice/cookie-compliance-for-wordpress": 20
     },


### PR DESCRIPTION
Removing Nightingale theme now that it has been replaced by Hale and
tested on Magi Rec.