### PR TITLE
Change composer packages to pull all versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   "require": {
     "php": ">=7.1",
     "composer/installers": "^1.4",
-    "aws/aws-sdk-php": "^3.147",
+    "aws/aws-sdk-php": "*",
     "vlucas/phpdotenv": "^2.0.1",
     "johnpbloch/wordpress": "*",
     "koodimonni-language/core-en_gb": "*",
@@ -52,7 +52,7 @@
     "sentry/sdk": "^3.1"
   },
   "require-dev": {
-    "squizlabs/php_codesniffer": "^3.0.2"
+    "squizlabs/php_codesniffer": "*"
   },
   "extra": {
     "installer-paths": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "07421c6ed5386d63a4c94851ac35ccb8",
+    "content-hash": "c6c22bd64750a21ebce0c9cfcef287fa",
     "packages": [
         {
             "name": "acf/advanced-custom-fields-pro",


### PR DESCRIPTION
Created a new composer lock file to see if this fixes the pipeline error. Everything got updated

  - Locking acf/advanced-custom-fields-pro (5.12.3)
  - Locking aws/aws-crt-php (v1.0.2)
  - Locking aws/aws-sdk-php (3.235.3)
  - Locking clue/stream-filter (v1.6.0)
  - Locking composer/installers (v1.12.0)
  - Locking guzzlehttp/guzzle (7.5.0)
  - Locking guzzlehttp/promises (1.5.2)
  - Locking guzzlehttp/psr7 (2.4.1)
  - Locking http-interop/http-factory-guzzle (1.2.0)
  - Locking jean85/pretty-package-versions (2.0.5)
  - Locking johnpbloch/wordpress (6.0.2)
  - Locking johnpbloch/wordpress-core (6.0.2)
  - Locking johnpbloch/wordpress-core-installer (2.0.0)
  - Locking koodimonni-language/core-en_gb (6.0.2)
  - Locking koodimonni/composer-dropin-installer (1.4)
  - Locking ministryofjustice/cookie-compliance-for-wordpress (3.3.0)
  - Locking ministryofjustice/wp-hale (3.2.7)
  - Locking ministryofjustice/wp-moj-blocks (3.7.1)
  - Locking ministryofjustice/wp-moj-components (3.5.1)
  - Locking ministryofjustice/wp-rewrite-media-to-s3 (0.3.1)
  - Locking ministryofjustice/wp-user-roles (1.0.1)
  - Locking mtdowling/jmespath.php (2.6.1)
  - Locking oscarotero/env (v1.2.0)
  - Locking php-http/client-common (2.5.0)
  - Locking php-http/discovery (1.14.3)
  - Locking php-http/httplug (2.3.0)
  - Locking php-http/message (1.13.0)
  - Locking php-http/message-factory (v1.0.2)
  - Locking php-http/promise (1.1.0)
  - Locking psr/container (1.1.2)
  - Locking psr/http-client (1.0.1)
  - Locking psr/http-factory (1.0.1)
  - Locking psr/http-message (1.0.1)
  - Locking psr/log (1.1.4)
  - Locking ralouphie/getallheaders (3.0.3)
  - Locking relevanssi/relevanssi-premium (2.18.0)
  - Locking roots/wp-password-bcrypt (1.1.0)
  - Locking sentry/sdk (3.2.0)
  - Locking sentry/sentry (3.8.0)
  - Locking squizlabs/php_codesniffer (3.7.1)
  - Locking symfony/deprecation-contracts (v2.5.2)
  - Locking symfony/http-client (v5.4.12)
  - Locking symfony/http-client-contracts (v2.5.2)
  - Locking symfony/options-resolver (v5.4.11)
  - Locking symfony/polyfill-ctype (v1.26.0)
  - Locking symfony/polyfill-mbstring (v1.26.0)
  - Locking symfony/polyfill-php73 (v1.26.0)
  - Locking symfony/polyfill-php80 (v1.26.0)
  - Locking symfony/service-contracts (v2.5.2)
  - Locking vlucas/phpdotenv (v2.6.9)
  - Locking wpackagist-plugin/ewww-image-optimizer (6.8.0)
  - Locking wpackagist-plugin/query-monitor (3.9.0)
  - Locking wpackagist-plugin/redirection (5.3.3)
  - Locking wpackagist-plugin/safe-svg (2.0.3)
  - Locking wpackagist-plugin/simple-301-redirects (2.0.6)
  - Locking wpackagist-plugin/unconfirmed (1.3.5)
  - Locking wpackagist-plugin/wordpress-seo (19.6.1)
  - Locking wpackagist-plugin/wp-force-login (5.6.3)